### PR TITLE
Upgrade to es2020

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,6 @@
 {
 	"compilerOptions": {
-		"lib": [
-			"es2019",
-			"es2020.bigint",
-			"es2020.string",
-			"es2020.symbol.wellknown",
-			"es2020.promise"
-		],
+		"lib": ["es2020"],
 
 		"module": "CommonJS",
 		"moduleResolution": "node",


### PR DESCRIPTION
"Promise.allSettled" requires es2020. Since we are using this frequently, we should support by our default config.

@see https://collaborne.slack.com/archives/D031UUTDR4G/p1691689808094539?thread_ts=1691689408.475919&cid=D031UUTDR4G